### PR TITLE
Home과 VideoDetail 연결

### DIFF
--- a/app/src/main/java/com/example/pooptube/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/pooptube/home/HomeFragment.kt
@@ -8,19 +8,12 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.pooptube.BuildConfig
 import com.example.pooptube.databinding.FragmentHomeBinding
-import com.example.pooptube.main.ApiConfig
-//import com.example.pooptube.main.MainActivity
+import com.example.pooptube.main.MainActivity
 import com.example.pooptube.myvideos.HomeFilterModel
-import com.example.pooptube.myvideos.VideosModelList
-//import com.example.pooptube.myvideos.YoutubeVideoItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
 
 
 class HomeFragment : Fragment() {
@@ -28,14 +21,16 @@ class HomeFragment : Fragment() {
     private lateinit var binding: FragmentHomeBinding
     private lateinit var homeChipAdapter: HomeChipAdapter
     private lateinit var homeVideoAdapter: HomeVideoAdapter
-    private val viewModel : HomeViewModel by viewModels()
+    private val viewModel: HomeViewModel by viewModels()
 
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         binding = FragmentHomeBinding.inflate(inflater, container, false)
         return binding.root
-
-
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -56,14 +51,11 @@ class HomeFragment : Fragment() {
             }
         })
 
-        /*homeVideoAdapter.setOnItemClickListener(object : HomeVideoAdapter.OnItemClickListener {
-            override fun onItemClick(position: Int) {
-                val videoData = selectedVideoData
-                if (videoData != null) {
-                    (requireActivity() as MainActivity).openVideoDetailFragment(videoData)
-                }
+        homeVideoAdapter.setOnItemClickListener(object : HomeVideoAdapter.OnItemClickListener {
+            override fun onItemClick(videoModel: HomeVideoModel) {
+                (requireActivity() as MainActivity).openVideoDetailFromHome(videoModel)
             }
-        })*/
+        })
 
         with(binding) {
             chipRecyclerView.itemAnimator = null
@@ -100,4 +92,3 @@ class HomeFragment : Fragment() {
         viewModel.fetchPopularVideos(categoryId)
     }
 }
-

--- a/app/src/main/java/com/example/pooptube/home/HomeVideoAdapter.kt
+++ b/app/src/main/java/com/example/pooptube/home/HomeVideoAdapter.kt
@@ -6,14 +6,13 @@ import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.example.pooptube.databinding.HomeItemVideoBinding
 import java.util.Date
-import kotlin.math.floor
 
 class HomeVideoAdapter : RecyclerView.Adapter<HomeVideoAdapter.VideoViewHolder>() {
 
     private var items: List<HomeVideoModel> = listOf()
 
     interface OnItemClickListener {
-        fun onItemClick(position: Int)
+        fun onItemClick(videoModel: HomeVideoModel)
     }
 
     private var listener: OnItemClickListener? = null
@@ -56,6 +55,10 @@ class HomeVideoAdapter : RecyclerView.Adapter<HomeVideoAdapter.VideoViewHolder>(
             }
             // 결과를 텍스트뷰에 설정합니다.
             binding.subTitleText.text = "${item.author} · 조회수 ${item.count} · $formattedDateTime"
+
+            itemView.setOnClickListener {
+                listener?.onItemClick(item)
+            }
         }
     }
 
@@ -70,7 +73,7 @@ class HomeVideoAdapter : RecyclerView.Adapter<HomeVideoAdapter.VideoViewHolder>(
     override fun onBindViewHolder(holder: VideoViewHolder, position: Int) {
         holder.bind(items[position])
         holder.itemView.setOnClickListener {
-            listener?.onItemClick(position)
+            listener?.onItemClick(items[position])
         }
     }
 

--- a/app/src/main/java/com/example/pooptube/home/HomeVideoModel.kt
+++ b/app/src/main/java/com/example/pooptube/home/HomeVideoModel.kt
@@ -1,12 +1,15 @@
 package com.example.pooptube.home
 
+import android.os.Parcelable
 import com.example.pooptube.myvideos.YoutubeVideoItem
+import kotlinx.parcelize.Parcelize
 import java.util.Date
 
 data class HomeVideoResponse(
     val items: List<YoutubeVideoItem>
 )
 
+@Parcelize
 data class HomeVideoModel(
     val imgThumbnail: String,
     val channelLogoImg: String,
@@ -14,7 +17,7 @@ data class HomeVideoModel(
     val author: String,
     val count: String,
     val dateTime: Date,
-)
+): Parcelable
 
 //data class YoutubeVideoItem(
 //    val snippet: Snippet,

--- a/app/src/main/java/com/example/pooptube/main/MainActivity.kt
+++ b/app/src/main/java/com/example/pooptube/main/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.commit
 import androidx.viewpager2.widget.ViewPager2
 import com.example.pooptube.R
 import com.example.pooptube.databinding.ActivityMainBinding
+import com.example.pooptube.home.HomeVideoModel
 import com.example.pooptube.myvideos.VideosModelList
 import com.example.pooptube.videodetail.VideoDetailFragment
 import com.google.android.material.tabs.TabLayout
@@ -48,10 +49,25 @@ class MainActivity : AppCompatActivity() {
         }.attach()
     }
 
-    fun openVideoDetailFragment(videoData: VideosModelList, position: Int) {
+    fun openVideoDetailFromHome(videoModel: HomeVideoModel) {
         val fragment = VideoDetailFragment()
         val bundle = Bundle()
 
+        bundle.putInt("fragment", 0)
+        bundle.putParcelable("videoData", videoModel)
+        fragment.arguments = bundle
+
+        supportFragmentManager.commit {
+            replace(R.id.video_detail_container, fragment)
+            addToBackStack(null)
+        }
+    }
+
+    fun openVideoDetail(videoData: VideosModelList, position: Int) {
+        val fragment = VideoDetailFragment()
+        val bundle = Bundle()
+
+        bundle.putInt("fragment", 1)
         bundle.putParcelable("videoData", videoData)
 //        bundle.putString("videoId", videoId)
         bundle.putInt("position", position)

--- a/app/src/main/java/com/example/pooptube/myvideos/MyVideosFragment.kt
+++ b/app/src/main/java/com/example/pooptube/myvideos/MyVideosFragment.kt
@@ -42,7 +42,7 @@ class MyVideosFragment : Fragment() {
             override fun onItemClick(position: Int) {
                 val videoData = viewModel.video.value
                 if (videoData != null && position >= 0 && position < videoData.items.size) {
-                    (requireActivity() as MainActivity).openVideoDetailFragment(videoData, position)
+                    (requireActivity() as MainActivity).openVideoDetail(videoData, position)
                 }
             }
         })

--- a/app/src/main/java/com/example/pooptube/search/SearchFragment.kt
+++ b/app/src/main/java/com/example/pooptube/search/SearchFragment.kt
@@ -76,11 +76,11 @@ class SearchFragment : Fragment() {
             override fun onItemClick(position: Int) {
                 val videoData = viewModel.searchResults.value
                 if (videoData != null && position >= 0 && position < videoData.items.size) {
-                    (requireActivity() as MainActivity).openVideoDetailFragment(videoData, position)
+                    (requireActivity() as MainActivity).openVideoDetail(videoData, position)
                     /*val videoId = videoData.items[position].videoId
                     if (videoId != null) {
                         (requireActivity() as MainActivity).openVideoDetailFragment(videoData, videoId, position)
-                    }*/
+                }*/
                 }
             }
         })

--- a/app/src/main/java/com/example/pooptube/videodetail/VideoDetailFragment.kt
+++ b/app/src/main/java/com/example/pooptube/videodetail/VideoDetailFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.Fragment
 import coil.load
 import com.example.pooptube.R
 import com.example.pooptube.databinding.FragmentVideoDetailBinding
+import com.example.pooptube.home.HomeVideoModel
 import com.example.pooptube.myvideos.VideosModelList
 
 class VideoDetailFragment : Fragment() {
@@ -30,29 +31,58 @@ class VideoDetailFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         val bundle = arguments
         if (bundle != null) {
-            val videoData =
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    bundle.getParcelable("videoData", VideosModelList::class.java)
-                } else {
-                    bundle.getParcelable("videoData")
+            val fragmentType = bundle.getInt("fragment", -1)
+
+            when (fragmentType) {
+                0 -> {
+                    // Home 프래그먼트에서 클릭한 경우
+                    val videoData =
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            bundle.getParcelable("videoData", HomeVideoModel::class.java)
+                        } else {
+                            bundle.getParcelable("videoData")
+                        }
+                    if (videoData != null) {
+                        val videoModel = VideoDetailModel(
+                            thumbnail = videoData.imgThumbnail,
+                            title = videoData.title,
+                            channelProfile = videoData.imgThumbnail,
+                            channelId = videoData.author,
+                            description = "Video Description", // HomeVideoModel에는 description이 없어서 잠시 비워둠...
+                            dateTime = videoData.dateTime,
+                            viewCount = videoData.count,
+                            isFavorite = false
+                        )
+                        bind(videoModel)
+                    }
                 }
-            val position = bundle.getInt("position", -1)
 
-            if (videoData != null && position >= 0 && position < videoData.items.size) {
-                val clickedItem = videoData.items[position]
-                val videoModel = VideoDetailModel(
-                    thumbnail = clickedItem.snippet.thumbnails.medium.url,
-                    title = clickedItem.snippet.title,
-                    channelProfile = clickedItem.snippet.thumbnails.medium.url,   // 지금 쓰는 엔드포인트에는 없어서 thumbnail로 대체
-                    channelId = clickedItem.snippet.channelTitle,
-                    description = clickedItem.snippet.description,
-                    dateTime = clickedItem.snippet.publishedAt,
-                    viewCount = clickedItem.statistics?.viewCount ?: "0",
+                1 -> {
+                    // 다른 프래그먼트에서 클릭한 경우
+                    val videoData =
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            bundle.getParcelable("videoData", VideosModelList::class.java)
+                        } else {
+                            bundle.getParcelable("videoData")
+                        }
+                    val position = bundle.getInt("position", -1)
+
+                    if (videoData != null && position >= 0 && position < videoData.items.size) {
+                        val clickedItem = videoData.items[position]
+                        val videoModel = VideoDetailModel(
+                            thumbnail = clickedItem.snippet.thumbnails.medium.url,
+                            title = clickedItem.snippet.title,
+                            channelProfile = clickedItem.snippet.thumbnails.medium.url,   // 지금 쓰는 엔드포인트에는 없어서 thumbnail로 대체
+                            channelId = clickedItem.snippet.channelTitle,
+                            description = clickedItem.snippet.description,
+                            dateTime = clickedItem.snippet.publishedAt,
+                            viewCount = clickedItem.statistics?.viewCount ?: "0",
 //                    videoId = clickedItem.videoId,
-                    isFavorite = false
-                )
-
-                bind(videoModel)
+                            isFavorite = false
+                        )
+                        bind(videoModel)
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Changes

1. MainActivity
- 비디오 아이템 클릭 시 해당 아이템의 세부 정보 전달하는 openVideoDetailFromHome 함수 생성
- openVideoDetailFragment -> openVideoDetail 함수명 변경

2. HomeAdapter
- OnItemClickListener 인터페이스에 onItemClick 함수의 인자 변경
- itemView.setOnClickListener를 사용하여 아이템 클릭 이벤트를 처리

3. HomeVideoModel
- HomeVideoModel 데이터 클래스 Parcelize, Parcelable 적용

4. VideoDetailFragment
- HomeFragment에서 클릭한 경우와 다른 프래그먼트에서 클릭한 경우를 구분하여 처리하도록 수정
- HomeFragment에서 클릭한 경우, HomeVideoModel을 기반으로 videoModel을 생성하도록 수정


close #46 