### PR TITLE
[DESIGN]: TabLayout, ToolBar 수정

### DIFF
--- a/app/src/main/java/com/example/pooptube/main/MainActivity.kt
+++ b/app/src/main/java/com/example/pooptube/main/MainActivity.kt
@@ -31,6 +31,8 @@ class MainActivity : AppCompatActivity() {
 
         toolbar = binding.mainToolbar
         setSupportActionBar(toolbar)
+        // 기존 label title 사용x
+        supportActionBar?.setDisplayShowTitleEnabled(false)
 
         val customToolbar: View? = layoutInflater.inflate(R.layout.custom_toolbar, toolbar, false)
         val logoImage = customToolbar?.findViewById<ImageView>(R.id.toolbar_logo)

--- a/app/src/main/java/com/example/pooptube/main/MainActivity.kt
+++ b/app/src/main/java/com/example/pooptube/main/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.pooptube.main
 
+import android.graphics.Color
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
@@ -31,12 +32,12 @@ class MainActivity : AppCompatActivity() {
         toolbar = binding.mainToolbar
         setSupportActionBar(toolbar)
 
-        val customToolbar = layoutInflater.inflate(R.layout.custom_toolbar, null)
-        val logoImage = customToolbar.findViewById<ImageView>(R.id.toolbar_logo)
-        val title = customToolbar.findViewById<TextView>(R.id.toolbar_title)
+        val customToolbar: View? = layoutInflater.inflate(R.layout.custom_toolbar, toolbar, false)
+        val logoImage = customToolbar?.findViewById<ImageView>(R.id.toolbar_logo)
+        val title = customToolbar?.findViewById<TextView>(R.id.toolbar_title)
 
-        logoImage.setImageResource(R.drawable.ic_poop)
-        title.text = "PoopTube"
+        logoImage?.setImageResource(R.drawable.ic_poop)
+        title?.text = "PoopTube"
 
         supportActionBar?.setDisplayShowCustomEnabled(true)
         supportActionBar?.customView = customToolbar
@@ -65,7 +66,48 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }.attach()
+
+        fun TabLayout.Tab.getCustomTextView(): TextView? {
+            val customView = this.customView ?: return null
+            return customView.findViewById(R.id.main_tablayout) as? TextView
+        }
+
+        // 선택된 탭과 선택되지 않은 탭의 색상
+        val selectedColor = Color.WHITE
+        val unselectedColor = Color.parseColor("#C47474")
+
+        tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab?) {
+                tab?.let {
+                    it.icon?.setTint(selectedColor)
+                    it.getCustomTextView()?.setTextColor(selectedColor)
+                }
+            }
+
+            override fun onTabUnselected(tab: TabLayout.Tab?) {
+                tab?.let {
+                    it.icon?.setTint(unselectedColor)
+                    it.getCustomTextView()?.setTextColor(unselectedColor)
+                }
+            }
+
+            override fun onTabReselected(tab: TabLayout.Tab?) {
+                // 재선택시 동작
+            }
+        })
+
+        // 초기 상태 설정
+        for (i in 0 until tabLayout.tabCount) {
+            tabLayout.getTabAt(i)?.icon?.setTint(unselectedColor)
+            tabLayout.getTabAt(i)?.view?.findViewById<TextView>(android.R.id.text1)?.setTextColor(unselectedColor)
+        }
+
+        // 현재 선택된 탭의 색상 설정
+        tabLayout.getTabAt(tabLayout.selectedTabPosition)?.icon?.setTint(selectedColor)
+        tabLayout.getTabAt(tabLayout.selectedTabPosition)?.view?.findViewById<TextView>(android.R.id.text1)?.setTextColor(selectedColor)
     }
+
+
 
     fun openVideoDetailFromHome(videoModel: HomeVideoModel) {
         val fragment = VideoDetailFragment()

--- a/app/src/main/res/color/main_tab_text_color_selector.xml
+++ b/app/src/main/res/color/main_tab_text_color_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="#FFFFFF" android:state_selected="true" />
+    <item android:color="#C47474" />
+</selector>

--- a/app/src/main/res/layout/custom_toolbar.xml
+++ b/app/src/main/res/layout/custom_toolbar.xml
@@ -8,9 +8,8 @@
     <!-- 이미지 뷰 -->
     <ImageView
         android:id="@+id/toolbar_logo"
-        android:layout_width="?attr/actionBarSize"
-        android:layout_height="match_parent"
-        android:padding="15dp"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:ignore="contentDescription" />
@@ -18,14 +17,14 @@
     <!-- 제목 텍스트 뷰 -->
     <TextView
         android:id="@+id/toolbar_title"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:textColor="#FFFFFF"
-        android:textSize="18sp"
+        android:textSize="22sp"
         android:textStyle="bold"
+        android:layout_marginStart="10dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/toolbar_logo"
         app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,7 +14,7 @@
     <style name="MyTabLayout" parent="Widget.Design.AppBarLayout">
         <item name="tabBackground">@color/selected_background_color</item>
         <item name="tabIconTint">@color/white</item>
-        <item name="tabTextColor">@color/white</item>
+        <item name="tabTextColor">@color/main_tab_text_color_selector</item>
     </style>
 
     <style name="Theme.Pooptube" parent="Base.Theme.Pooptube" />


### PR DESCRIPTION
TabLayout 클릭했을때, 안했을때 수정

ToolBar는 커스텀 선언으로 인해, 툴바안에 AppName이 제일 앞에 나오고,
커스텀안에 있는 TextView가 공간이 없어서 출력이 안되는 문제였음.
ToolBar 안에 Appname(label)을 공백으로 주고, 커스텀 안에 TextView의 공간을 다시 잡아줌